### PR TITLE
Feature/docs cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Application
+APP_PORT=8080
+
+# Postgres connection (used by config loader via APP_ prefix)
+APP_POSTGRES_HOST=localhost
+APP_POSTGRES_PORT=5432
+APP_POSTGRES_USER=postgres
+APP_POSTGRES_PASSWORD=postgres
+APP_POSTGRES_DB=basketball
+APP_POSTGRES_SSLMODE=disable
+
+# Optional: explicit DSN for goose/tools
+# DATABASE_URL=postgres://postgres:postgres@localhost:5432/basketball?sslmode=disable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           version: latest
           args: --timeout=5m
 
+      - name: Validate OpenAPI (Redocly)
+        run: |
+          npm i -g @redocly/cli
+          redocly lint api/openapi.yaml
+
       - name: Wait for Postgres (service health)
         run: |
           for i in {1..30}; do

--- a/.gitignore
+++ b/.gitignore
@@ -1,43 +1,52 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
-# Binaries for programs and plugins
-/basketball-stats-service
-/server
+# Coverage reports
+coverage.out
+coverage.html
+coverage/
+*.cov
+*.coverprofile
+*.pprof
+
+# IDE/editor config
+.idea/
+*.iml
+.vscode/
+.fleet/
+
+# Logs
+*.log
+/test/logs/
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+bin/
+build/
+dist/
+out/
+
+# Go build/test binaries
+*.test
 *.exe
 *.dll
 *.so
 *.dylib
 
-# Test binary, built with `go test -c`
-*.test
+# Temporary files
+*.tmp
+*.swp
+*.swo
+*~
 
-# Code coverage profiles and other test artifacts
-coverage.*
-*.out
-*.coverprofile
-profile.cov
-/coverage.out
-/coverage.html
+# Env and local tooling (keep .env.example tracked)
+.env
+.env.local
+.env.*.local
+!.env.example
+.envrc
+.direnv/
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-# Go workspace file
+# Go workspace files (usually local-only; skip if you commit workspace)
 go.work
 go.work.sum
-
-# env file
-.env
-
-# Editor/IDE
-.idea/
-.vscode/
-
-# Local logs
-/test/logs/
-logs/
-
-# Misc
-.DS_Store
-/op/

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+/basketball-stats-service
+/server
 *.exe
-*.exe~
 *.dll
 *.so
 *.dylib
@@ -12,10 +13,12 @@
 *.test
 
 # Code coverage profiles and other test artifacts
-*.out
 coverage.*
+*.out
 *.coverprofile
 profile.cov
+/coverage.out
+/coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
@@ -28,5 +31,13 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
+
+# Local logs
+/test/logs/
+logs/
+
+# Misc
+.DS_Store
+/op/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -o basketball-stats ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o server ./cmd/server
 
 FROM gcr.io/distroless/base
-COPY --from=builder /app/basketball-stats /basketball-stats
-ENTRYPOINT ["/basketball-stats"]
+WORKDIR /app
+COPY --from=builder /app/server /app/server
+# Ship runtime assets needed by the server
+COPY --from=builder /app/config.yaml /app/config.yaml
+COPY --from=builder /app/api /app/api
+EXPOSE 8080
+ENTRYPOINT ["/app/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY --from=builder /app/server /app/server
 COPY --from=builder /app/config.yaml /app/config.yaml
 COPY --from=builder /app/api /app/api
 EXPOSE 8080
+USER 10001
 ENTRYPOINT ["/app/server"]

--- a/README.md
+++ b/README.md
@@ -1,49 +1,111 @@
-# basketball-stats-service
-NBA Basketball Stats Service — Go, Postgres, Docker. Home assignment for Skyhawk Security.
+# Basketball Stats Service (Go + Postgres)
 
-## Validation & Errors
+A production-grade, containerized service for logging NBA player statistics and serving up-to-date aggregates. Built in Go with clean architecture and a focus on validation, reliability, and developer ergonomics.
 
-Сервисный слой выполняет нормализацию и доменную валидацию до обращения к БД. Правила:
-- Строки trim.
-- Enum (position/status) приводятся к единому регистру.
-- Пагинация: limit <=0 -> 50, limit>100 -> 100, offset<0 -> 0.
-- Все нарушения агрегируются в один ErrInvalidInput c массивом field_errors.
+## Highlights
+- Clean architecture: Handlers → Services → Repositories → Postgres.
+- Strong validation in the service layer; consistent HTTP error mapping.
+- Up-to-date aggregates for players and teams (career or seasonal).
+- Containerized with Docker; one-command local stack via Docker Compose.
+- OpenAPI spec + Swagger UI at runtime.
+- CI pipeline with linting, migrations, and tests (including repository contracts).
 
-HTTP маппинг ошибок:
-| Error | HTTP | payload.error |
-|-------|------|---------------|
-| ErrInvalidInput | 400 | invalid_input |
-| ErrNotFound | 404 | not_found |
-| ErrAlreadyExists | 409 | already_exists |
-| ErrConflict | 409 | conflict |
-| (прочее) | 500 | internal_error |
+## Quick start
+Prerequisites: Go 1.25+, Docker, Docker Compose.
 
-Пример 400:
+1) Start Postgres via Docker Compose:
+```bash
+make docker-up
 ```
-{
-  "error": "invalid_input",
-  "message": "one or more fields are invalid",
-  "field_errors": [
-    {"field": "name", "message": "must not be empty"},
-    {"field": "position", "message": "must be one of PG, SG, SF, PF, C"}
-  ]
-}
+2) Apply DB migrations:
+```bash
+make migrate-up
+```
+3) Run the service:
+```bash
+make run
+```
+4) Open docs:
+- Swagger UI: http://localhost:8080/docs
+- OpenAPI spec: http://localhost:8080/openapi.yaml
+
+Health:
+```bash
+curl -s http://localhost:8080/ready | jq
 ```
 
-## Make Targets (основные)
-- `make run` — запустить сервис.
-- `make test` — все тесты.
-- `make test-contract` — контрактные тесты репозитория (при наличии Postgres).
+## API overview
+Base path: /api/v1
 
-## Структура слоёв
-- handler -> service -> repository -> Postgres.
-- handler ничего не знает про pgx.
-- service ничего не знает про SQL/pgx.
-- repository не знает про HTTP / gin.
+- Health:
+  - GET /health/live
+  - GET /health/ready
+- Teams:
+  - POST /teams
+  - GET /teams
+  - GET /teams/{team_id}
+  - GET /teams/{team_id}/aggregates (alias: /teams/{team_id}/stats/aggregate)
+- Players:
+  - POST /players
+  - GET /players/{id}
+  - GET /teams/{team_id}/players
+  - GET /players/{id}/aggregates (alias: /players/{id}/stats/aggregate)
+- Stats:
+  - POST /stats (upsert stat line)
+  - GET /games/{id}/stats
 
-## Roadmap (кратко)
-- [x] Repository contracts + contract tests.
-- [x] Service validation дизайн.
-- [x] HTTP error mapping.
-- [ ] Unit tests services (частично — skeleton добавлен).
-- [ ] Game & Stats handlers.
+Examples (aggregates):
+```bash
+curl -s "http://localhost:8080/api/v1/players/1/aggregates?career=true" | jq
+curl -s "http://localhost:8080/api/v1/players/1/aggregates?season=2023-24" | jq
+curl -s "http://localhost:8080/api/v1/teams/1/aggregates?season=2023-24" | jq
+```
+
+## Validation & errors
+The service normalizes and validates input before hitting the DB. Key rules:
+- Strings: trim and normalize case (enums to canonical set).
+- Pagination: default limit=50; clamp to [1..100]; offset>=0.
+- Stats constraints: integers ≥ 0, Fouls ∈ [0..6], Minutes Played ∈ [0..48.0].
+- Player and Game existence verified before writes.
+
+HTTP error mapping (pkg/response):
+- 400 invalid_input (+ field_errors array)
+- 404 not_found
+- 409 already_exists/conflict
+- 500 internal_error
+
+## Development
+- Tests (aggregated coverage):
+```bash
+make test
+```
+- Contract tests (require Postgres):
+```bash
+make test-contract
+```
+- Lint & vet:
+```bash
+make ci
+```
+
+## Configuration
+Configuration is loaded from config.yaml and can be overridden by env vars.
+- App port: APP_PORT
+- DB connection: APP_POSTGRES_HOST, APP_POSTGRES_PORT, APP_POSTGRES_USER, APP_POSTGRES_PASSWORD, APP_POSTGRES_DB, APP_POSTGRES_SSLMODE
+
+See .env.example for a starter set.
+
+## Architecture & deployment
+- System architecture: docs/ARCHITECTURE.md
+- Cloud deployment sketch (AWS/GCP/Azure): docs/DEPLOYMENT.md
+
+In short: the service runs as a stateless container behind a load balancer and talks to Postgres. Horizontal scaling is straightforward; repository layer is designed for contract testing and future persistence adapters.
+
+## Why this design
+- Separation of concerns keeps handlers thin and services focused on business rules.
+- Repository contracts with error mapping to domain errors decouple higher layers from SQL/pg errors.
+- Strong validation provides clear 400s to clients and reduces unnecessary DB traffic.
+- Tests focus on contracts and core logic to enable safe refactors.
+
+## License
+MIT

--- a/README.md
+++ b/README.md
@@ -49,12 +49,18 @@ Base path: /api/v1
   - GET /teams/{team_id}/aggregates (alias: /teams/{team_id}/stats/aggregate)
 - Players:
   - POST /players
-  - GET /players/{id}
-  - GET /teams/{team_id}/players
-  - GET /players/{id}/aggregates (alias: /players/{id}/stats/aggregate)
+  - GET /players
+  - GET /players/{player_id}
+  - GET /players/{player_id}/aggregates (alias: /players/{player_id}/stats/aggregate)
+- Games:
+  - POST /games
+  - GET /games
+  - GET /games/{game_id}
+  - GET /games/{game_id}/stats
 - Stats:
-  - POST /stats (upsert stat line)
-  - GET /games/{id}/stats
+  - POST /stats
+  - GET /stats
+  - GET /stats/{stat_id}
 
 Examples (aggregates):
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A production-grade, containerized service for logging NBA player statistics and serving up-to-date aggregates. Built in Go with clean architecture and a focus on validation, reliability, and developer ergonomics.
 
+![Architecture](docs/diagrams/architecture.svg)
+
 ## Highlights
 - Clean architecture: Handlers → Services → Repositories → Postgres.
 - Strong validation in the service layer; consistent HTTP error mapping.
@@ -98,6 +100,8 @@ See .env.example for a starter set.
 ## Architecture & deployment
 - System architecture: docs/ARCHITECTURE.md
 - Cloud deployment sketch (AWS/GCP/Azure): docs/DEPLOYMENT.md
+
+![Deployment](docs/diagrams/deployment.svg)
 
 In short: the service runs as a stateless container behind a load balancer and talks to Postgres. Horizontal scaling is straightforward; repository layer is designed for contract testing and future persistence adapters.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,6 +5,7 @@ info:
   description: HTTP API for teams, players, games and stats, including aggregated endpoints.
 servers:
   - url: /api/v1
+security: []
 paths:
   /health/live:
     get:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,288 @@
+openapi: 3.0.3
+info:
+  title: Basketball Stats Service API
+  version: 1.0.0
+  description: HTTP API for teams, players, games and stats, including aggregated endpoints.
+servers:
+  - url: /api/v1
+paths:
+  /health/live:
+    get:
+      summary: Liveness probe
+      responses:
+        '200':
+          description: Alive
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+  /health/ready:
+    get:
+      summary: Readiness probe
+      responses:
+        '200':
+          description: Ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Health'
+        '503':
+          description: Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthError'
+  /teams:
+    get:
+      summary: List teams
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 0 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0 }
+      responses:
+        '200':
+          description: Page of teams
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageResultTeam'
+    post:
+      summary: Create team
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string, minLength: 2, maxLength: 50 }
+              required: [name]
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+        '409': { description: Conflict, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /teams/{team_id}:
+    get:
+      summary: Get team by ID
+      parameters:
+        - in: path
+          name: team_id
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Team' } } } }
+        '404': { description: Not found, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /teams/{team_id}/aggregates:
+    get:
+      summary: Aggregated statistics for a team
+      parameters:
+        - in: path
+          name: team_id
+          required: true
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: season
+          schema: { type: string, pattern: "^[0-9]{4}-[0-9]{2}$" }
+        - in: query
+          name: career
+          schema: { type: boolean }
+          description: If true, returns career aggregates; cannot be used with season.
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/TeamAggregatedStats' } } } }
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+        '404': { description: Not found, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /players:
+    post:
+      summary: Create player
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                team_id: { type: integer, minimum: 1 }
+                first_name: { type: string, minLength: 1, maxLength: 50 }
+                last_name: { type: string, minLength: 1, maxLength: 50 }
+                position: { type: string, enum: [pg, sg, sf, pf, c] }
+              required: [team_id, first_name, last_name, position]
+      responses:
+        '201': { description: Created, content: { application/json: { schema: { $ref: '#/components/schemas/Player' } } } }
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+        '409': { description: Conflict (team not found / FK), content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /players/{id}:
+    get:
+      summary: Get player by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Player' } } } }
+        '404': { description: Not found, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /teams/{team_id}/players:
+    get:
+      summary: List players by team
+      parameters:
+        - in: path
+          name: team_id
+          required: true
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 0 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0 }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/PageResultPlayer' } } } }
+  /players/{id}/aggregates:
+    get:
+      summary: Aggregated statistics for a player
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: season
+          schema: { type: string, pattern: "^[0-9]{4}-[0-9]{2}$" }
+        - in: query
+          name: career
+          schema: { type: boolean }
+          description: If true, returns career aggregates; cannot be used with season.
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/PlayerAggregatedStats' } } } }
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+        '404': { description: Not found, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /stats:
+    post:
+      summary: Upsert a player's stat line for a game
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PlayerStatLineInput' }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/PlayerStatLine' } } } }
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+        '409': { description: Conflict (FK), content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /games/{id}/stats:
+    get:
+      summary: List stat lines for a game
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/PlayerStatLine' } } } } }
+        '400': { description: Invalid input, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+components:
+  schemas:
+    Health:
+      type: object
+      properties:
+        status: { type: string, example: ready }
+    HealthError:
+      type: object
+      properties:
+        status: { type: string, example: unavailable }
+        error: { type: string }
+    ErrorResponse:
+      type: object
+      properties:
+        error: { type: string, example: invalid_input }
+        field_errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field: { type: string }
+              message: { type: string }
+    Team:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    Player:
+      type: object
+      properties:
+        id: { type: integer }
+        team_id: { type: integer }
+        first_name: { type: string }
+        last_name: { type: string }
+        position: { type: string, enum: [pg, sg, sf, pf, c] }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    PlayerStatLineInput:
+      type: object
+      properties:
+        player_id: { type: integer }
+        game_id: { type: integer }
+        points: { type: integer, minimum: 0 }
+        rebounds: { type: integer, minimum: 0 }
+        assists: { type: integer, minimum: 0 }
+        steals: { type: integer, minimum: 0 }
+        blocks: { type: integer, minimum: 0 }
+        fouls: { type: integer, minimum: 0 }
+        turnovers: { type: integer, minimum: 0 }
+        minutes_played: { type: number, minimum: 0, maximum: 60 }
+      required: [player_id, game_id]
+    PlayerStatLine:
+      allOf:
+        - $ref: '#/components/schemas/PlayerStatLineInput'
+        - type: object
+          properties:
+            id: { type: integer }
+            created_at: { type: string, format: date-time }
+            updated_at: { type: string, format: date-time }
+    TeamAggregatedStats:
+      type: object
+      properties:
+        games_played: { type: integer }
+        wins: { type: integer }
+        losses: { type: integer }
+        avg_points: { type: number }
+        avg_rebounds: { type: number }
+        avg_assists: { type: number }
+    PlayerAggregatedStats:
+      type: object
+      properties:
+        games_played: { type: integer }
+        total_points: { type: integer }
+        total_rebounds: { type: integer }
+        total_assists: { type: integer }
+        avg_points: { type: number }
+        avg_rebounds: { type: number }
+        avg_assists: { type: number }
+    Page:
+      type: object
+      properties:
+        limit: { type: integer }
+        offset: { type: integer }
+    PageResultTeam:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Team' }
+        total: { type: integer }
+    PageResultPlayer:
+      type: object
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Player' }
+        total: { type: integer }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,7 +42,6 @@ func main() {
 	if err != nil {
 		appLogger.Fatal().Err(err).Msg("failed to init repository")
 	}
-	defer repo.Close()
 
 	// Wire repositories (postgres implementations) and services
 	pool := repo.Pool()
@@ -92,5 +91,10 @@ func main() {
 		appLogger.Error().Err(err).Msg("server forced to shutdown")
 	}
 
+	// Close repository pool explicitly before exiting
+	repo.Close()
+
 	appLogger.Info().Msg("Server exited")
+	// Guarantee success exit code for local runs (make run)
+	os.Exit(0)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       APP_PORT: ${APP_PORT:-8080}
     ports:
       - "${APP_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
     env_file:
       - .env
     environment:
-      DB_USER: ${POSTGRES_USER:-postgres}
-      DB_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      DB_NAME: ${POSTGRES_DB:-basketball}
+      APP_POSTGRES_HOST: db
+      APP_POSTGRES_PORT: 5432
+      APP_PORT: ${APP_PORT:-8080}
     ports:
       - "${APP_PORT:-8080}:8080"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Architecture
+
+This service follows a clean architecture layout with clear separation of concerns:
+
+- HTTP handlers (Gin): routing, DTO binding, basic syntax validation and error mapping using pkg/response.
+- Services: business rules, input normalization, domain validation, existence checks, and orchestrating repositories.
+- Repositories: persistence access (pgxpool), SQL <-> domain mapping, and mapping PG errors to domain errors.
+- Postgres: durable store with migrations (goose), indexes/constraints for integrity and performance.
+
+## Data flow
+
+Write (Upsert stat line):
+1. Handler receives JSON (machine-to-machine input), binds DTO.
+2. Service validates: IDs > 0, integers >= 0, Fouls ∈ [0..6], Minutes Played ∈ [0..48.0]; normalizes.
+3. Service checks existence (player and game). No pre-check uniqueness—leave it for DB.
+4. Repository upserts using ON CONFLICT, returning the current row state.
+5. Handler returns 200 with the updated line.
+
+Read (Aggregates):
+1. Handler parses query (season or career=true) and enforces mutual exclusivity.
+2. Service validates IDs and season format, normalizes.
+3. Repository runs aggregate queries (GROUP BY / SUM / AVG etc.), returns typed results.
+4. Handler returns 200 with JSON.
+
+## Error model
+- Service returns domain errors:
+  - ErrInvalidInput (with field_errors)
+  - ErrNotFound, ErrAlreadyExists, ErrConflict
+- Handlers map them to HTTP via pkg/response.
+
+## Health & readiness
+- /live returns process liveness.
+- /ready pings DB via a minimal repository interface (Pinger) to validate critical dependencies.
+
+## Testing strategy
+- Unit tests: service validation and business rules, using fakes.
+- Contract tests: repository interfaces against Postgres (migrations applied beforehand), verifying behavior and error mapping.
+- Handler tests: httptest for endpoints, error mapping, and corner cases.
+
+## Scalability considerations
+- Stateless app containers; horizontal scale behind a load balancer.
+- Postgres: connection pool sizing (min/max), health checks, and timeouts tuned in config.
+- Write-read path is designed to surface new data immediately after write (upsert), ensuring aggregates reflect latest persisted stats.
+
+## Extensibility
+- Repositories are interfaces; adding a cache layer or an alternative store is possible by implementing the same contracts.
+- Validation lives in services, enabling new rules without touching I/O layers.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,54 @@
+# Deployment
+
+This project ships as a stateless container. You can run it locally with Docker Compose or deploy to a cloud platform orchestrator.
+
+## Local (Docker Compose)
+
+Prerequisites: Docker, Docker Compose.
+
+1) Copy environment template and adjust if needed:
+```bash
+cp .env.example .env
+```
+2) Start the stack (Postgres + app):
+```bash
+docker compose up -d --build
+```
+3) Apply DB migrations (one-time):
+```bash
+make migrate-up
+```
+4) Open the app:
+- http://localhost:8080/docs (Swagger UI)
+- http://localhost:8080/openapi.yaml (OpenAPI)
+
+## Production (cloud sketch)
+
+A minimal production setup on AWS could look like this:
+
+- Networking & LB: Amazon ALB (or NLB) terminates TLS and forwards to app tasks.
+- Compute: Amazon ECS (Fargate) or EKS (Kubernetes) runs stateless app containers with desired count ≥ 2.
+- Database: Amazon RDS for PostgreSQL with multi-AZ, automated backups, and monitoring.
+- Secrets: AWS Secrets Manager for DB credentials; inject via task definitions / env.
+- Observability: CloudWatch Logs + metrics (container and app), alarms on error rate/latency.
+- CI/CD: GitHub Actions builds/pushes the Docker image to ECR and updates ECS service.
+
+### ECS deployment flow
+1. GitHub Actions builds the image (multi-stage Dockerfile) and pushes to ECR.
+2. Task definition references the ECR image and injects env vars (APP_POSTGRES_*).
+3. ECS service with desired count (e.g., 3) behind an ALB target group.
+4. ALB health checks call /ready.
+
+### Kubernetes (EKS) flow
+- Deployments with HPA (CPU/latency based), Service (ClusterIP) + Ingress (ALB Ingress Controller).
+- Config via ConfigMap/Secret; mount or env-inject APP_POSTGRES_*.
+- Liveness/readiness probes pointing to /live and /ready.
+
+## Scaling & performance notes
+- App is stateless; horizontal scaling is straightforward.
+- Tune pgx pool via config (max/min conns, timeouts) per environment and DB capacity.
+- Use connection reuse and avoid long transactions; upserts are idempotent and short-lived.
+
+## Migrations in CI/CD
+- Apply goose migrations as a dedicated step before rolling out a new app version.
+- For zero-downtime, keep migrations backward-compatible with the previous app version.

--- a/docs/diagrams/architecture.svg
+++ b/docs/diagrams/architecture.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="520" viewBox="0 0 920 520">
+  <style>
+    .title { font: 700 20px sans-serif; }
+    .label { font: 600 14px sans-serif; }
+    .note { font: 12px sans-serif; fill: #444; }
+    .box { fill:#f8fafc; stroke:#0f172a; stroke-width:1.5; rx:8; }
+    .arrow { stroke:#0f172a; stroke-width:1.5; marker-end:url(#arrow); fill:none; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#0f172a"/>
+    </marker>
+  </defs>
+  <text x="20" y="30" class="title">Basketball Stats - Clean Architecture</text>
+
+  <!-- Client -->
+  <rect x="40" y="80" width="180" height="60" class="box"/>
+  <text x="60" y="115" class="label">Clients (M2M / API consumers)</text>
+
+  <!-- Gin HTTP -->
+  <rect x="280" y="70" width="220" height="80" class="box"/>
+  <text x="300" y="100" class="label">HTTP Handlers (Gin)</text>
+  <text x="300" y="120" class="note">routing, DTO binding, error mapping</text>
+
+  <!-- Services -->
+  <rect x="280" y="190" width="220" height="110" class="box"/>
+  <text x="300" y="220" class="label">Services (business rules)</text>
+  <text x="300" y="240" class="note">validation, normalization, orchestration</text>
+  <text x="300" y="260" class="note">aggregates, transactions</text>
+
+  <!-- Repositories -->
+  <rect x="280" y="340" width="220" height="100" class="box"/>
+  <text x="300" y="370" class="label">Repositories (pgx)</text>
+  <text x="300" y="390" class="note">SQL↔domain mapping, error mapping</text>
+
+  <!-- Postgres -->
+  <rect x="580" y="340" width="240" height="100" class="box"/>
+  <text x="600" y="370" class="label">PostgreSQL</text>
+  <text x="600" y="390" class="note">migrations (goose), constraints, indexes</text>
+
+  <!-- Arrows -->
+  <line x1="220" y1="110" x2="280" y2="110" class="arrow"/>
+  <line x1="390" y1="150" x2="390" y2="190" class="arrow"/>
+  <line x1="390" y1="300" x2="390" y2="340" class="arrow"/>
+  <line x1="500" y1="390" x2="580" y2="390" class="arrow"/>
+
+  <!-- Health/Readiness -->
+  <rect x="580" y="190" width="240" height="110" class="box"/>
+  <text x="600" y="220" class="label">Observability</text>
+  <text x="600" y="240" class="note">/live, /ready (Pinger)</text>
+  <text x="600" y="260" class="note">structured logs (zerolog)</text>
+</svg>

--- a/docs/diagrams/deployment.svg
+++ b/docs/diagrams/deployment.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="560" viewBox="0 0 980 560">
+  <style>
+    .title { font: 700 20px sans-serif; }
+    .label { font: 600 14px sans-serif; }
+    .note { font: 12px sans-serif; fill: #444; }
+    .box { fill:#fff; stroke:#0f172a; stroke-width:1.5; rx:8; }
+    .cloud { fill:#eef2ff; stroke:#3730a3; stroke-width:1.5; rx:10; }
+    .arrow { stroke:#0f172a; stroke-width:1.5; marker-end:url(#arrow); fill:none; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#0f172a"/>
+    </marker>
+  </defs>
+  <text x="20" y="30" class="title">Production deployment (cloud sketch)</text>
+
+  <!-- ALB / Ingress -->
+  <rect x="60" y="90" width="220" height="80" class="cloud"/>
+  <text x="80" y="120" class="label">Load Balancer / Ingress</text>
+  <text x="80" y="140" class="note">TLS termination, /live /ready checks</text>
+
+  <!-- App Service -->
+  <rect x="360" y="70" width="260" height="120" class="box"/>
+  <text x="380" y="110" class="label">App Service (ECS/EKS)</text>
+  <text x="380" y="130" class="note">stateless containers, autoscaling</text>
+
+  <!-- Postgres -->
+  <rect x="360" y="250" width="260" height="110" class="box"/>
+  <text x="380" y="285" class="label">PostgreSQL (RDS)</text>
+  <text x="380" y="305" class="note">multi-AZ, backups, monitoring</text>
+
+  <!-- Secrets -->
+  <rect x="680" y="70" width="240" height="80" class="box"/>
+  <text x="700" y="110" class="label">Secrets Manager</text>
+
+  <!-- Observability -->
+  <rect x="680" y="200" width="240" height="120" class="box"/>
+  <text x="700" y="235" class="label">Observability</text>
+  <text x="700" y="255" class="note">logs, metrics, alerts</text>
+
+  <!-- Arrows -->
+  <line x1="280" y1="130" x2="360" y2="130" class="arrow"/>
+  <line x1="490" y1="190" x2="490" y2="250" class="arrow"/>
+  <line x1="620" y1="110" x2="680" y2="110" class="arrow"/>
+  <line x1="620" y1="260" x2="680" y2="260" class="arrow"/>
+</svg>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,3 +1,0 @@
-// Package app contains top-level application wiring or composition roots.
-// I keep it intentionally minimal until the app needs explicit lifecycle management.
-package app

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -37,6 +37,12 @@ func Load(path string) (*Config, error) {
 	if err := v.BindEnv("postgres.dbname", "APP_POSTGRES_DB", "POSTGRES_DB", "DB_NAME"); err != nil {
 		return nil, err
 	}
+	// Optional: host/port/sslmode overrides
+	_ = v.BindEnv("postgres.host", "APP_POSTGRES_HOST", "POSTGRES_HOST")
+	_ = v.BindEnv("postgres.port", "APP_POSTGRES_PORT", "POSTGRES_PORT")
+	_ = v.BindEnv("postgres.sslmode", "APP_POSTGRES_SSLMODE", "POSTGRES_SSLMODE")
+	// app.port: allow APP_APP_PORT or APP_PORT
+	_ = v.BindEnv("app.port", "APP_APP_PORT", "APP_PORT")
 
 	// Read config file
 	if err := v.ReadInConfig(); err != nil {
@@ -44,7 +50,15 @@ func Load(path string) (*Config, error) {
 	}
 
 	// Ensure env-bound keys are materialized so Unmarshal sees them even if absent in YAML
-	for _, key := range []string{"postgres.user", "postgres.password", "postgres.dbname"} {
+	for _, key := range []string{
+		"postgres.user",
+		"postgres.password",
+		"postgres.dbname",
+		"postgres.host",
+		"postgres.port",
+		"postgres.sslmode",
+		"app.port",
+	} {
 		if val := v.GetString(key); val != "" {
 			v.Set(key, val)
 		}

--- a/internal/handler/docs.go
+++ b/internal/handler/docs.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	_ "embed"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Minimal HTML that loads Swagger UI from a CDN and points to /openapi.yaml.
+// This avoids bundling assets and keeps the binary small.
+//
+//go:embed swagger.html
+var swaggerHTML string
+
+// RegisterDocs mounts documentation endpoints at the root:
+//   - GET /openapi.yaml: raw OpenAPI spec served from repository path api/openapi.yaml
+//   - GET /docs: Swagger UI rendering of the spec
+func RegisterDocs(r *gin.Engine) {
+	r.GET("/openapi.yaml", func(c *gin.Context) {
+		data, err := os.ReadFile("api/openapi.yaml")
+		if err != nil {
+			c.String(http.StatusInternalServerError, "failed to read openapi spec: %v", err)
+			return
+		}
+		c.Data(http.StatusOK, "application/yaml; charset=utf-8", data)
+	})
+	r.GET("/docs", func(c *gin.Context) {
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(swaggerHTML))
+	})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -14,6 +14,9 @@ func Register(r *gin.Engine, repo Pinger, teamSvc service.TeamService, playerSvc
 	r.GET("/live", h.Liveness)
 	r.GET("/ready", h.Readiness)
 
+	// Docs endpoints (root-level)
+	RegisterDocs(r)
+
 	api := r.Group(APIV1Prefix) // Versioning added via single source of truth
 	{
 		health := api.Group("/health")

--- a/internal/handler/swagger.html
+++ b/internal/handler/swagger.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Basketball Stats Service API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  <style> body { margin: 0; } #swagger-ui { max-width: 100%; } </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.addEventListener('load', () => {
+      window.ui = SwaggerUIBundle({
+        url: '/openapi.yaml',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+      });
+    });
+  </script>
+</body>
+</html>

--- a/internal/repository/postgres/player_postgres.go
+++ b/internal/repository/postgres/player_postgres.go
@@ -113,9 +113,9 @@ func (r *playerRepository) GetPlayerAggregatedStats(ctx context.Context, playerI
 			COALESCE(SUM(ps.assists), 0) AS total_assists,
 			COALESCE(SUM(ps.steals), 0) AS total_steals,
 			COALESCE(SUM(ps.blocks), 0) AS total_blocks,
-			COALESCE(AVG(ps.points), 0) AS avg_points,
-			COALESCE(AVG(ps.rebounds), 0) AS avg_rebounds,
-			COALESCE(AVG(ps.assists), 0) AS avg_assists
+			COALESCE(ROUND(AVG(ps.points), 2), 0) AS avg_points,
+			COALESCE(ROUND(AVG(ps.rebounds), 2), 0) AS avg_rebounds,
+			COALESCE(ROUND(AVG(ps.assists), 2), 0) AS avg_assists
 		FROM
 			player_stats ps
 		INNER JOIN games g ON ps.game_id = g.id

--- a/internal/repository/postgres/team_postgres.go
+++ b/internal/repository/postgres/team_postgres.go
@@ -146,8 +146,8 @@ func (r *teamRepository) GetTeamAggregatedStats(ctx context.Context, teamID int6
 			COALESCE(SUM(CASE WHEN loser_id = $1 THEN 1 ELSE 0 END), 0) AS losses,
 			COALESCE(SUM(CASE WHEN home_team_id = $1 THEN home_points ELSE away_points END), 0) AS total_points_scored,
 			COALESCE(SUM(CASE WHEN home_team_id = $1 THEN away_points ELSE home_points END), 0) AS total_points_allowed,
-			COALESCE(AVG(CASE WHEN home_team_id = $1 THEN home_points ELSE away_points END), 0) AS avg_points_scored,
-			COALESCE(AVG(CASE WHEN home_team_id = $1 THEN away_points ELSE home_points END), 0) AS avg_points_allowed
+			COALESCE(ROUND(AVG(CASE WHEN home_team_id = $1 THEN home_points ELSE away_points END), 2), 0) AS avg_points_scored,
+			COALESCE(ROUND(AVG(CASE WHEN home_team_id = $1 THEN away_points ELSE home_points END), 2), 0) AS avg_points_allowed
 		FROM game_results
 		WHERE home_team_id = $1 OR away_team_id = $1
 	`

--- a/internal/service/stats.go
+++ b/internal/service/stats.go
@@ -9,6 +9,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const (
+	maxFouls        = 6
+	maxMinutesFloat = 48.0
+)
+
 type statsService struct {
 	stats   repository.StatsRepository
 	players repository.PlayerRepository
@@ -45,14 +50,14 @@ func (s *statsService) UpsertStatLine(ctx context.Context, line model.PlayerStat
 	if line.Blocks < 0 {
 		ferrs = append(ferrs, FieldError{Field: "blocks", Message: "must be >= 0"})
 	}
-	if line.Fouls < 0 {
-		ferrs = append(ferrs, FieldError{Field: "fouls", Message: "must be >= 0"})
+	if line.Fouls < 0 || line.Fouls > maxFouls {
+		ferrs = append(ferrs, FieldError{Field: "fouls", Message: "must be between 0 and 6"})
 	}
 	if line.Turnovers < 0 {
 		ferrs = append(ferrs, FieldError{Field: "turnovers", Message: "must be >= 0"})
 	}
-	if line.MinutesPlayed < 0 {
-		ferrs = append(ferrs, FieldError{Field: "minutes_played", Message: "must be >= 0"})
+	if line.MinutesPlayed < 0 || float64(line.MinutesPlayed) > maxMinutesFloat {
+		ferrs = append(ferrs, FieldError{Field: "minutes_played", Message: "must be between 0 and 48.0"})
 	}
 
 	if err := NewInvalidInputError(ferrs); err != nil {

--- a/migrations/goose_sql/002_indexes.sql
+++ b/migrations/goose_sql/002_indexes.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- Add indexes for performance on foreign keys and filtering
+CREATE INDEX IF NOT EXISTS idx_players_team_id ON players(team_id);
+CREATE INDEX IF NOT EXISTS idx_games_season ON games(season);
+CREATE INDEX IF NOT EXISTS idx_games_date ON games(date);
+CREATE INDEX IF NOT EXISTS idx_games_home_team_id ON games(home_team_id);
+CREATE INDEX IF NOT EXISTS idx_games_away_team_id ON games(away_team_id);
+CREATE INDEX IF NOT EXISTS idx_player_stats_player_id ON player_stats(player_id);
+CREATE INDEX IF NOT EXISTS idx_player_stats_game_id ON player_stats(game_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_players_team_id;
+DROP INDEX IF EXISTS idx_games_season;
+DROP INDEX IF EXISTS idx_games_date;
+DROP INDEX IF EXISTS idx_games_home_team_id;
+DROP INDEX IF EXISTS idx_games_away_team_id;
+DROP INDEX IF EXISTS idx_player_stats_player_id;
+DROP INDEX IF EXISTS idx_player_stats_game_id;

--- a/test/service/stats_service_test.go
+++ b/test/service/stats_service_test.go
@@ -88,6 +88,8 @@ func TestStatsService_UpsertStatLine_Validation(t *testing.T) {
 		{"negative stat", model.PlayerStatLine{PlayerID: 2, GameID: 3, Points: -1}, true, "points"},
 		{"player missing", model.PlayerStatLine{PlayerID: 9, GameID: 3}, true, "player_id"},
 		{"game missing", model.PlayerStatLine{PlayerID: 2, GameID: 99}, true, "game_id"},
+		{"fouls over max", model.PlayerStatLine{PlayerID: 2, GameID: 3, Fouls: 7}, true, "fouls"},
+		{"minutes too high", model.PlayerStatLine{PlayerID: 2, GameID: 3, MinutesPlayed: 49.0}, true, "minutes_played"},
 		{"ok", model.PlayerStatLine{PlayerID: 2, GameID: 3, Points: 10}, false, ""},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This pull request introduces several major improvements to the basketball stats service, focusing on developer experience, documentation, configuration, and deployment. The highlights are a comprehensive new `README.md`, a full OpenAPI specification for the HTTP API, improved Docker and CI workflows, and a new architecture document. Environment variable handling and health checks have also been standardized for better reliability and local development.

**Documentation & API Specification**
- Added a detailed OpenAPI 3.0 spec in `api/openapi.yaml`, covering all endpoints, request/response schemas, and error models for the service. This enables automated validation, client generation, and interactive docs.
- Rewrote and expanded `README.md` to include quick start instructions, API usage examples, configuration, architecture, and rationale for design decisions, making onboarding and usage much easier.
- Added a new architecture overview in `docs/ARCHITECTURE.md`, documenting the service's clean architecture, data flow, error handling, health checks, and testing strategy.

**Configuration & Environment**
- Introduced a `.env.example` with all necessary environment variables for app and Postgres configuration, clarifying local and production setup.
- Updated `docker-compose.yml` to use the new `APP_POSTGRES_*` env vars, set up a healthcheck for the service, and simplified environment handling.

**Build, CI, and Deployment**
- Refined the `Dockerfile` for production: builds a static Linux binary, sets up a minimal runtime image, ships only required assets, and runs as a non-root user for security.
- Improved the Makefile `run` target to better capture and interpret server exit codes, treating graceful shutdowns as success for local development.
- Enhanced CI pipeline (`.github/workflows/ci.yml`) by adding OpenAPI linting via Redocly, ensuring the API spec remains valid and up-to-date.

**Code & Service Lifecycle**
- Ensured explicit closing of the repository pool and a guaranteed zero exit code after graceful shutdown in `cmd/server/main.go`, improving local dev experience and resource cleanup. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL45) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR94-R99)